### PR TITLE
[FEAT] orders API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,9 @@
         "@nestjs/mapped-types": "^2.0.5",
         "@nestjs/passport": "^10.0.3",
         "@nestjs/platform-express": "^10.0.0",
+        "@nestjs/platform-socket.io": "^10.4.4",
         "@nestjs/typeorm": "^10.0.2",
+        "@nestjs/websockets": "^10.4.4",
         "bcrypt": "^5.1.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
@@ -26,6 +28,7 @@
         "passport-jwt": "^4.0.1",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1",
+        "socket.io": "^4.8.0",
         "typeorm": "^0.3.20",
         "uuid": "^10.0.0"
       },
@@ -1807,6 +1810,74 @@
         "@nestjs/core": "^10.0.0"
       }
     },
+    "node_modules/@nestjs/platform-socket.io": {
+      "version": "10.4.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-10.4.4.tgz",
+      "integrity": "sha512-5GEYUA3sNbX2jOBP6FmrIK/zv9VCdvpdr4Sef1OKvt1U0qsV1YgmWPWDPumZM77n5DI0VHSJPyo7yjZaEKWOiQ==",
+      "dependencies": {
+        "socket.io": "4.7.5",
+        "tslib": "2.7.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0",
+        "@nestjs/websockets": "^10.0.0",
+        "rxjs": "^7.1.0"
+      }
+    },
+    "node_modules/@nestjs/platform-socket.io/node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nestjs/platform-socket.io/node_modules/engine.io": {
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.5.tgz",
+      "integrity": "sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA==",
+      "dependencies": {
+        "@types/cookie": "^0.4.1",
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.4.1",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/@nestjs/platform-socket.io/node_modules/socket.io": {
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.5.tgz",
+      "integrity": "sha512-DmeAkF6cwM9jSfmp6Dr/5/mfMwb5Z5qRrSXLpo3Fq5SqyU8CMF15jIN4ZhfSwu35ksM1qmHZDQ/DK5XTccSTvA==",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.3.2",
+        "engine.io": "~6.5.2",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/@nestjs/platform-socket.io/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+    },
     "node_modules/@nestjs/schematics": {
       "version": "10.1.4",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-10.1.4.tgz",
@@ -1883,6 +1954,33 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/@nestjs/websockets": {
+      "version": "10.4.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-10.4.4.tgz",
+      "integrity": "sha512-ZHnak04i/iKBS0csjJa7K6D6xdsB0Yz6duJuCR7xGLItchFK+Ne21m9rEF8ffvW74U7UAYkQHBgD5242LBBYiQ==",
+      "dependencies": {
+        "iterare": "1.2.1",
+        "object-hash": "3.0.0",
+        "tslib": "2.7.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0",
+        "@nestjs/core": "^10.0.0",
+        "@nestjs/platform-socket.io": "^10.0.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0",
+        "rxjs": "^7.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@nestjs/platform-socket.io": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/websockets/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1980,6 +2078,11 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
     },
     "node_modules/@sqltools/formatter": {
       "version": "1.2.5",
@@ -2080,11 +2183,24 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
+    },
     "node_modules/@types/cookiejar": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
       "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
       "dev": true
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.17",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
+      "integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/dotenv": {
       "version": "8.2.0",
@@ -3119,6 +3235,14 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
     },
     "node_modules/bcrypt": {
       "version": "5.1.1",
@@ -4191,6 +4315,42 @@
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.1.tgz",
+      "integrity": "sha512-NEpDCw9hrvBW+hVEOK4T7v0jFJ++KgtPl4jKFwsZVfG1XhS0dCrSb3VMb9gPAd7VAdW52VT1EnaNiU2vM8C0og==",
+      "dependencies": {
+        "@types/cookie": "^0.4.1",
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.4.1",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -7178,6 +7338,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
@@ -8269,6 +8437,44 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/socket.io": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.0.tgz",
+      "integrity": "sha512-8U6BEgGjQOfGz3HHTYaC/L1GaxDCJ/KM0XTkJly0EhZ5U/du9uNEZy4ZgYzEzIqlx2CMm25CrCqr1ck899eLNA==",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.3.2",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+      "dependencies": {
+        "debug": "~4.3.4",
+        "ws": "~8.17.1"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/source-map": {
@@ -9573,6 +9779,26 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "@nestjs/mapped-types": "^2.0.5",
     "@nestjs/passport": "^10.0.3",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/platform-socket.io": "^10.4.4",
     "@nestjs/typeorm": "^10.0.2",
+    "@nestjs/websockets": "^10.4.4",
     "bcrypt": "^5.1.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
@@ -37,6 +39,7 @@
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",
+    "socket.io": "^4.8.0",
     "typeorm": "^0.3.20",
     "uuid": "^10.0.0"
   },

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,6 +13,7 @@ import { CategoriesModule } from './categories/categories.module';
 import { AuthModule } from './auth/auth.module';
 import { MenusController } from './menus/menus.controller';
 import { MenusModule } from './menus/menus.module';
+import { OrdersModule } from './orders/orders.module';
 import * as dotenv from 'dotenv';
 
 dotenv.config();
@@ -41,6 +42,7 @@ dotenv.config();
     CategoriesModule,
     AuthModule,
     MenusModule,
+    OrdersModule,
   ],
   controllers: [UsersController, RestaurantsController, HealthCheckController, MenusController, CategoriesController],
   providers: [],

--- a/src/menus/entities/menus.entity.ts
+++ b/src/menus/entities/menus.entity.ts
@@ -1,4 +1,5 @@
 import { Option } from 'src/options/entities/options.entity';
+import { Order } from 'src/orders/entities/orders.entity';
 import { Column, CreateDateColumn, Entity, OneToMany, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
 
 @Entity('menus')
@@ -45,4 +46,7 @@ export class Menus {
 
   @OneToMany(() => Option, (option) => option.menu, { eager: true })
   options: Option[];
+
+  @OneToMany(() => Order, (order) => order.menu)
+  orders: Order[];
 }

--- a/src/menus/menus.module.ts
+++ b/src/menus/menus.module.ts
@@ -3,9 +3,10 @@ import { Menus } from './entities/menus.entity';
 import { MenusController } from './menus.controller';
 import { MenusService } from './menus.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { Order } from 'src/orders/entities/orders.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Menus])],
+  imports: [TypeOrmModule.forFeature([Menus, Order])],
   controllers: [MenusController],
   providers: [MenusService],
   exports: [MenusService],

--- a/src/orders/dto/create-orders.dto.ts
+++ b/src/orders/dto/create-orders.dto.ts
@@ -1,0 +1,11 @@
+import { IsUUID, IsInt, IsNotEmpty } from 'class-validator';
+
+export class CreateOrderDto {
+  @IsUUID()
+  @IsNotEmpty()
+  menu_id: string;
+
+  @IsInt()
+  @IsNotEmpty()
+  count: number;
+}

--- a/src/orders/dto/order-summary.dto.ts
+++ b/src/orders/dto/order-summary.dto.ts
@@ -1,0 +1,7 @@
+export class OrderSummaryDto {
+  id: string;
+  table_num: number;
+  menu_name: string;
+  price: number;
+  count: number;
+}

--- a/src/orders/dto/order-table-summary.dto.ts
+++ b/src/orders/dto/order-table-summary.dto.ts
@@ -1,0 +1,8 @@
+export class OrderTableSummaryDto {
+  id: string;
+  table_num: number;
+  menu_name: string;
+  price: number;
+  count: number;
+  total_price: number;
+}

--- a/src/orders/entities/orders.entity.ts
+++ b/src/orders/entities/orders.entity.ts
@@ -1,0 +1,45 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Restaurant } from 'src/restaurants/entities/restaurants.entity';
+import { RestaurantTable } from 'src/restaurantTables/entities/restaurantTables.entity';
+import { Menus } from 'src/menus/entities/menus.entity';
+
+@Entity('orders')
+export class Order {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'timestamp', nullable: true })
+  ordered_at: Date;
+
+  @Column({ type: 'int', nullable: true })
+  count: number;
+
+  @Column({ type: 'int', nullable: true })
+  total_price: number;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  created_at: Date;
+
+  @UpdateDateColumn({ type: 'timestamp' })
+  updated_at: Date;
+
+  @ManyToOne(() => Restaurant, (restaurant) => restaurant.orders)
+  @JoinColumn({ name: 'restaurant_id' })
+  restaurant: Restaurant;
+
+  @ManyToOne(() => RestaurantTable, (restaurantTable) => restaurantTable.orders)
+  @JoinColumn({ name: 'restaurantTable_id' })
+  restaurantTable: RestaurantTable;
+
+  @ManyToOne(() => Menus, (menu) => menu.orders)
+  @JoinColumn({ name: 'menu_id' })
+  menu: Menus;
+}

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('orders')
+export class OrdersController {}

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -1,4 +1,14 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Post, Body } from '@nestjs/common';
+import { OrdersService } from './orders.service';
+import { CreateOrderDto } from './dto/create-orders.dto';
+import { Order } from './entities/orders.entity';
 
 @Controller('orders')
-export class OrdersController {}
+export class OrdersController {
+  constructor(private readonly ordersService: OrdersService) {}
+
+  @Post()
+  async createOrder(@Body() createOrderDto: CreateOrderDto): Promise<Order> {
+    return this.ordersService.createOrder(createOrderDto);
+  }
+}

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -1,11 +1,17 @@
-import { Controller, Post, Body, Param } from '@nestjs/common';
+import { Controller, Post, Body, Param, Get } from '@nestjs/common';
 import { OrdersService } from './orders.service';
 import { CreateOrderDto } from './dto/create-orders.dto';
 import { Order } from './entities/orders.entity';
+import { OrderSummaryDto } from './dto/order-summary.dto';
 
 @Controller('orders')
 export class OrdersController {
   constructor(private readonly ordersService: OrdersService) {}
+
+  @Get(':restaurant_id')
+  async findAllOrdersByRestaurant(@Param('restaurant_id') restaurant_id: string): Promise<OrderSummaryDto[]> {
+    return this.ordersService.findAllOrdersByRestaurant(restaurant_id);
+  }
 
   @Post(':restaurant_id/:restaurantTable_id')
   async createOrder(

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -3,10 +3,19 @@ import { OrdersService } from './orders.service';
 import { CreateOrderDto } from './dto/create-orders.dto';
 import { Order } from './entities/orders.entity';
 import { OrderSummaryDto } from './dto/order-summary.dto';
+import { OrderTableSummaryDto } from './dto/order-table-summary.dto';
 
 @Controller('orders')
 export class OrdersController {
   constructor(private readonly ordersService: OrdersService) {}
+
+  @Get(':restaurant_id/table/:table_num')
+  async findAllOrdersByRestaurantAndTable(
+    @Param('restaurant_id') restaurant_id: string,
+    @Param('table_num') table_num: number,
+  ): Promise<OrderTableSummaryDto[]> {
+    return this.ordersService.findAllOrdersByRestaurantAndTable(restaurant_id, table_num);
+  }
 
   @Get(':restaurant_id')
   async findAllOrdersByRestaurant(@Param('restaurant_id') restaurant_id: string): Promise<OrderSummaryDto[]> {

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body } from '@nestjs/common';
+import { Controller, Post, Body, Param } from '@nestjs/common';
 import { OrdersService } from './orders.service';
 import { CreateOrderDto } from './dto/create-orders.dto';
 import { Order } from './entities/orders.entity';
@@ -7,8 +7,12 @@ import { Order } from './entities/orders.entity';
 export class OrdersController {
   constructor(private readonly ordersService: OrdersService) {}
 
-  @Post()
-  async createOrder(@Body() createOrderDto: CreateOrderDto): Promise<Order> {
-    return this.ordersService.createOrder(createOrderDto);
+  @Post(':restaurant_id/:restaurantTable_id')
+  async createOrder(
+    @Param('restaurant_id') restaurant_id: string,
+    @Param('restaurantTable_id') restaurantTable_id: string,
+    @Body() createOrderDto: CreateOrderDto,
+  ): Promise<Order> {
+    return this.ordersService.createOrder(createOrderDto, restaurant_id, restaurantTable_id);
   }
 }

--- a/src/orders/orders.gateway.ts
+++ b/src/orders/orders.gateway.ts
@@ -1,0 +1,14 @@
+import { WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
+import { Server } from 'socket.io';
+
+@WebSocketGateway()
+export class OrdersGateway {
+  @WebSocketServer()
+  server: Server;
+
+  sendOrderUpdate(orderData: any) {
+    this.server.emit('orderUpdate', orderData); // 클라이언트에게 주문 업데이트 전송
+  }
+}
+
+export default OrdersGateway;

--- a/src/orders/orders.module.ts
+++ b/src/orders/orders.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { OrdersController } from './orders.controller';
+import { OrdersService } from './orders.service';
+
+@Module({
+  controllers: [OrdersController],
+  providers: [OrdersService]
+})
+export class OrdersModule {}

--- a/src/orders/orders.module.ts
+++ b/src/orders/orders.module.ts
@@ -1,9 +1,16 @@
 import { Module } from '@nestjs/common';
 import { OrdersController } from './orders.controller';
 import { OrdersService } from './orders.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Order } from './entities/orders.entity';
+import { Restaurant } from 'src/restaurants/entities/restaurants.entity';
+import { RestaurantTable } from 'src/restaurantTables/entities/restaurantTables.entity';
+import { Menus } from 'src/menus/entities/menus.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Order, Restaurant, RestaurantTable, Menus])],
   controllers: [OrdersController],
-  providers: [OrdersService]
+  providers: [OrdersService],
+  exports: [OrdersService],
 })
 export class OrdersModule {}

--- a/src/orders/orders.module.ts
+++ b/src/orders/orders.module.ts
@@ -6,11 +6,12 @@ import { Order } from './entities/orders.entity';
 import { Restaurant } from 'src/restaurants/entities/restaurants.entity';
 import { RestaurantTable } from 'src/restaurantTables/entities/restaurantTables.entity';
 import { Menus } from 'src/menus/entities/menus.entity';
+import OrdersGateway from './orders.gateway';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Order, Restaurant, RestaurantTable, Menus])],
   controllers: [OrdersController],
-  providers: [OrdersService],
+  providers: [OrdersService, OrdersGateway],
   exports: [OrdersService],
 })
 export class OrdersModule {}

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class OrdersService {}

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -6,6 +6,7 @@ import { CreateOrderDto } from './dto/create-orders.dto';
 import { Menus } from 'src/menus/entities/menus.entity';
 import { Restaurant } from 'src/restaurants/entities/restaurants.entity';
 import { RestaurantTable } from 'src/restaurantTables/entities/restaurantTables.entity';
+import { OrderSummaryDto } from './dto/order-summary.dto';
 
 @Injectable()
 export class OrdersService {
@@ -22,6 +23,26 @@ export class OrdersService {
     @InjectRepository(RestaurantTable)
     private restaurantTableRepository: Repository<RestaurantTable>,
   ) {}
+
+  async findAllOrdersByRestaurant(restaurant_id: string): Promise<OrderSummaryDto[]> {
+    const orders = await this.ordersRepository.find({
+      where: { restaurant: { id: restaurant_id } },
+      relations: ['menu', 'restaurantTable'],
+    });
+
+    if (!orders.length) {
+      throw new NotFoundException(`No orders found for restaurant with id ${restaurant_id}`);
+    }
+
+    // 필요한 정보만 추출하여 반환
+    return orders.map((order) => ({
+      id: order.id,
+      table_num: order.restaurantTable.table_num,
+      menu_name: order.menu.menu_name,
+      price: order.menu.price,
+      count: order.count,
+    }));
+  }
 
   async createOrder(createOrderDto: CreateOrderDto, restaurant_id: string, restaurantTable_id: string): Promise<Order> {
     const { menu_id, count } = createOrderDto;

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -1,4 +1,39 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Order } from './entities/orders.entity';
+import { CreateOrderDto } from './dto/create-orders.dto';
+import { Menus } from 'src/menus/entities/menus.entity';
 
 @Injectable()
-export class OrdersService {}
+export class OrdersService {
+  constructor(
+    @InjectRepository(Order)
+    private ordersRepository: Repository<Order>,
+
+    @InjectRepository(Menus)
+    private menusRepository: Repository<Menus>,
+  ) {}
+
+  async createOrder(createOrderDto: CreateOrderDto): Promise<Order> {
+    const { menu_id, count } = createOrderDto;
+
+    const menu = await this.menusRepository.findOne({ where: { id: menu_id } });
+
+    if (!menu) {
+      throw new NotFoundException('Menu not found');
+    }
+
+    // total_price는 메뉴의 가격 * 주문한 수량으로 계산
+    const total_price = menu.price * count;
+
+    const order = this.ordersRepository.create({
+      menu,
+      count,
+      total_price,
+      ordered_at: new Date(),
+    });
+
+    return this.ordersRepository.save(order);
+  }
+}

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -4,6 +4,8 @@ import { Repository } from 'typeorm';
 import { Order } from './entities/orders.entity';
 import { CreateOrderDto } from './dto/create-orders.dto';
 import { Menus } from 'src/menus/entities/menus.entity';
+import { Restaurant } from 'src/restaurants/entities/restaurants.entity';
+import { RestaurantTable } from 'src/restaurantTables/entities/restaurantTables.entity';
 
 @Injectable()
 export class OrdersService {
@@ -13,25 +15,46 @@ export class OrdersService {
 
     @InjectRepository(Menus)
     private menusRepository: Repository<Menus>,
+
+    @InjectRepository(Restaurant)
+    private restaurantsRepository: Repository<Restaurant>,
+
+    @InjectRepository(RestaurantTable)
+    private restaurantTableRepository: Repository<RestaurantTable>,
   ) {}
 
-  async createOrder(createOrderDto: CreateOrderDto): Promise<Order> {
+  async createOrder(createOrderDto: CreateOrderDto, restaurant_id: string, restaurantTable_id: string): Promise<Order> {
     const { menu_id, count } = createOrderDto;
 
+    // 메뉴를 찾음
     const menu = await this.menusRepository.findOne({ where: { id: menu_id } });
-
     if (!menu) {
       throw new NotFoundException('Menu not found');
     }
 
-    // total_price는 메뉴의 가격 * 주문한 수량으로 계산
+    // 레스토랑을 찾음
+    const restaurant = await this.restaurantsRepository.findOne({ where: { id: restaurant_id } });
+    if (!restaurant) {
+      throw new NotFoundException('Restaurant not found');
+    }
+
+    // 테이블을 찾음
+    const restaurantTable = await this.restaurantTableRepository.findOne({ where: { id: restaurantTable_id } });
+    if (!restaurantTable) {
+      throw new NotFoundException('Restaurant Table not found');
+    }
+
+    // 총 가격 계산 (메뉴 가격 * 수량)
     const total_price = menu.price * count;
 
+    // 주문 생성
     const order = this.ordersRepository.create({
       menu,
       count,
       total_price,
       ordered_at: new Date(),
+      restaurant,
+      restaurantTable,
     });
 
     return this.ordersRepository.save(order);

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -7,6 +7,7 @@ import { Menus } from 'src/menus/entities/menus.entity';
 import { Restaurant } from 'src/restaurants/entities/restaurants.entity';
 import { RestaurantTable } from 'src/restaurantTables/entities/restaurantTables.entity';
 import { OrderSummaryDto } from './dto/order-summary.dto';
+import { OrderTableSummaryDto } from './dto/order-table-summary.dto';
 
 @Injectable()
 export class OrdersService {
@@ -23,6 +24,30 @@ export class OrdersService {
     @InjectRepository(RestaurantTable)
     private restaurantTableRepository: Repository<RestaurantTable>,
   ) {}
+
+  async findAllOrdersByRestaurantAndTable(restaurant_id: string, table_num: number): Promise<OrderTableSummaryDto[]> {
+    const orders = await this.ordersRepository.find({
+      where: {
+        restaurant: { id: restaurant_id },
+        restaurantTable: { table_num },
+      },
+      relations: ['menu', 'restaurantTable'],
+    });
+
+    if (!orders.length) {
+      throw new NotFoundException(`No orders found for restaurant_id ${restaurant_id} and table number ${table_num}`);
+    }
+
+    // 필요한 정보만 추출하여 반환
+    return orders.map((order) => ({
+      id: order.id,
+      table_num: order.restaurantTable.table_num,
+      menu_name: order.menu.menu_name,
+      price: order.menu.price,
+      count: order.count,
+      total_price: order.total_price,
+    }));
+  }
 
   async findAllOrdersByRestaurant(restaurant_id: string): Promise<OrderSummaryDto[]> {
     const orders = await this.ordersRepository.find({

--- a/src/restaurantTables/entities/restaurantTables.entity.ts
+++ b/src/restaurantTables/entities/restaurantTables.entity.ts
@@ -1,5 +1,6 @@
-import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn } from 'typeorm';
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn, OneToMany } from 'typeorm';
 import { Restaurant } from 'src/restaurants/entities/restaurants.entity';
+import { Order } from 'src/orders/entities/orders.entity';
 
 @Entity('restaurantTables')
 export class RestaurantTable {
@@ -12,4 +13,7 @@ export class RestaurantTable {
 
   @Column()
   table_num: number;
+
+  @OneToMany(() => Order, (order) => order.restaurantTable)
+  orders: Order[];
 }

--- a/src/restaurantTables/restaurantTables.module.ts
+++ b/src/restaurantTables/restaurantTables.module.ts
@@ -6,9 +6,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Restaurant } from 'src/restaurants/entities/restaurants.entity';
 import { UrlsService } from 'src/urls/urls.service';
 import { Url } from 'src/urls/entities/urls.entity';
+import { Order } from 'src/orders/entities/orders.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([RestaurantTable, Restaurant, Url])],
+  imports: [TypeOrmModule.forFeature([RestaurantTable, Restaurant, Url, Order])],
   controllers: [RestaurantTablesController],
   providers: [RestaurantTablesService, UrlsService],
   exports: [RestaurantTablesService],

--- a/src/restaurants/entities/restaurants.entity.ts
+++ b/src/restaurants/entities/restaurants.entity.ts
@@ -2,6 +2,7 @@ import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateCol
 import { IsString, IsInt, MaxLength } from 'class-validator';
 import { RestaurantTable } from 'src/restaurantTables/entities/restaurantTables.entity';
 import { Url } from 'src/urls/entities/urls.entity';
+import { Order } from 'src/orders/entities/orders.entity';
 
 @Entity('restaurants')
 export class Restaurant {
@@ -56,4 +57,7 @@ export class Restaurant {
 
   @OneToMany(() => Url, (url) => url.restaurant)
   urls: Url[];
+
+  @OneToMany(() => Order, (order) => order.restaurant)
+  orders: Order[];
 }

--- a/src/restaurants/restaurants.module.ts
+++ b/src/restaurants/restaurants.module.ts
@@ -6,9 +6,10 @@ import { Restaurant } from './entities/restaurants.entity';
 import { RestaurantTable } from 'src/restaurantTables/entities/restaurantTables.entity';
 import { Url } from 'src/urls/entities/urls.entity';
 import { UrlsService } from 'src/urls/urls.service';
+import { Order } from 'src/orders/entities/orders.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Restaurant, RestaurantTable, Url])],
+  imports: [TypeOrmModule.forFeature([Restaurant, RestaurantTable, Url, Order])],
   controllers: [RestaurantsController],
   providers: [RestaurantsService, UrlsService],
   exports: [RestaurantsService, RestaurantsModule],


### PR DESCRIPTION
### 작업 개요
- 주문내역 식당 별 조회 api
- 주문내역 특정 식당의 특정 테이블 별 조회 api
- 주문내역 추가 api
- 주문내역 추가될 때 socket.io를 사용해 실시간 업데이트

### 반영 브랜치
feat_orders -> dev

### 연관된 이슈(optional)
- #11 

### 기타 참고 사항(optional)
- socket.io 적용을 위해 프론트에도 코드 추가 필요합니다.
- 현재는 socket.io를 통한 업데이트가 모든 사용자에게 적용되는데 해당하는 식당에만 업데이트를 전송하도록 수정하는 방법(ex. 특정 사용자만 사용할 수 있는 방을 만들고, 해당 방에만 메세지를 전송)을 생각중입니다. socket.io를 처음 다뤄봐서 조언 주시면 감사하겠습니다.
- 추후 주문내역 수정/삭제 api 추가할 예정입니다.

### 체크리스트
- [x] 코드가 정상적으로 작동하고 모든 테스트를 통과했나요?
- [x] 문서화가 필요한 경우, 문서화가 완료되었나요?
- [x] 코드 스타일 가이드라인을 따랐나요?
- [x] 관련된 모든 이슈가 링크되었나요?
- [x] 필요한 경우, 팀원에게 알렸나요?
