### PR TITLE
[FEAT] 카테고리 별 메뉴 조회 추가 query 이용

### DIFF
--- a/src/menus/menus.controller.ts
+++ b/src/menus/menus.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Param, Post, Put, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Post, Put, Query, UseGuards } from '@nestjs/common';
 import { MenusService } from './menus.service';
 import { Menus } from './entities/menus.entity';
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
@@ -11,8 +11,11 @@ export class MenusController {
 
   @UseGuards(JwtAuthGuard)
   @Get(':restaurant_id')
-  async getAllMenus(@Param('restaurant_id') restaurantId: string): Promise<Menus[]> {
-    return await this.menusService.getAllMenus(restaurantId);
+  async getAllMenus(
+    @Param('restaurant_id') restaurantId: string,
+    @Query('category_id') categoryId?: string,
+  ): Promise<Menus[]> {
+    return await this.menusService.getAllMenus(restaurantId, categoryId);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/src/menus/menus.service.ts
+++ b/src/menus/menus.service.ts
@@ -14,12 +14,12 @@ export class MenusService {
 
   //Todo: 유저가 매개변수로 받은 restaurantId의 주인이 맞는지 확인하는 로직 필요
   async getAllMenus(restaurantId: string, categoryId?: string): Promise<Menus[]> {
-    const query = {
+    const menuFilter = {
       restaurant_id: restaurantId,
       ...(categoryId && { category_id: categoryId }),
     };
 
-    const menus = await this.menuRepository.find({ where: query, relations: ['options'] });
+    const menus = await this.menuRepository.find({ where: menuFilter, relations: ['options'] });
 
     if (menus.length === 0) {
       throw new NotFoundException('해당 조건에 맞는 메뉴가 없습니다.');

--- a/src/menus/menus.service.ts
+++ b/src/menus/menus.service.ts
@@ -13,10 +13,16 @@ export class MenusService {
   ) {}
 
   //Todo: 유저가 매개변수로 받은 restaurantId의 주인이 맞는지 확인하는 로직 필요
-  async getAllMenus(restaurantId: string): Promise<Menus[]> {
-    const menus = await this.menuRepository.find({ where: { restaurant_id: restaurantId }, relations: ['options'] });
+  async getAllMenus(restaurantId: string, categoryId?: string): Promise<Menus[]> {
+    const query = {
+      restaurant_id: restaurantId,
+      ...(categoryId && { category_id: categoryId }),
+    };
+
+    const menus = await this.menuRepository.find({ where: query, relations: ['options'] });
+
     if (menus.length === 0) {
-      throw new NotFoundException('레스토랑의 메뉴가 없습니다.');
+      throw new NotFoundException('해당 조건에 맞는 메뉴가 없습니다.');
     }
 
     return menus;


### PR DESCRIPTION
### 작업 개요
- 카테고리 별 메뉴 조회 추가 query 이용

### 반영 브랜치
- feat_menu_getByCategory -> main

### 연관된 이슈(optional)
- #17 

### 변경 사항(optional)
- `menus.controller.ts` , `menus.service.ts` : query에 category_id가 있으면 카테고리 별 조회로 

### 해결 과정(optional)
- 

### 기타 참고 사항(optional)
- 

### 체크리스트
- [x] 코드가 정상적으로 작동하고 모든 테스트를 통과했나요?
- [x] 문서화가 필요한 경우, 문서화가 완료되었나요?
- [x] 코드 스타일 가이드라인을 따랐나요?
- [x] 관련된 모든 이슈가 링크되었나요?
- [x] 필요한 경우, 팀원에게 알렸나요?
