### PR TITLE
[FEAT] designPresets API

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -19,6 +19,7 @@ import { OptionsModule } from './options/options.module';
 import { CallsModule } from './calls/calls.module';
 import { ImgUploadModule } from './img-upload/imgUpload.module';
 import { DesignsModule } from './designs/designs.module';
+import { DesignPresetsModule } from './designPresets/designPresets.module';
 import * as dotenv from 'dotenv';
 
 dotenv.config();
@@ -52,6 +53,7 @@ dotenv.config();
     CallsModule,
     ImgUploadModule,
     DesignsModule,
+    DesignPresetsModule,
   ],
   controllers: [
     UsersController,

--- a/src/designPresets/designPresets.controller.ts
+++ b/src/designPresets/designPresets.controller.ts
@@ -1,4 +1,47 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Post, Put, Delete, Param, Body, Request, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
+import { DesignPresetsService } from './designPresets.service';
+import { CreateDesignPresetDto } from './dto/create-designPresets.dto';
+import { UpdateDesignPresetDto } from './dto/update-designPresets.dto';
+import { DesignPreset } from './entities/designPresets.entity';
 
-@Controller('design-presets')
-export class DesignPresetsController {}
+@UseGuards(JwtAuthGuard)
+@Controller('designPresets')
+export class DesignPresetsController {
+  constructor(private readonly designPresetsService: DesignPresetsService) {}
+
+  @Get()
+  async getDesignPresets(@Request() req): Promise<DesignPreset[]> {
+    const restaurantId = req.user.restaurantId;
+
+    return this.designPresetsService.getDesignPresets(restaurantId);
+  }
+
+  @Get(':designPreset_id')
+  async getDesignPresetById(@Param('designPreset_id') designPresetId: string): Promise<DesignPreset> {
+    return this.designPresetsService.getDesignPresetById(designPresetId);
+  }
+
+  @Post()
+  async createDesignPreset(
+    @Request() req,
+    @Body() createDesignPresetDto: CreateDesignPresetDto,
+  ): Promise<DesignPreset> {
+    const restaurantId = req.user.restaurantId;
+
+    return this.designPresetsService.createDesignPreset(restaurantId, createDesignPresetDto);
+  }
+
+  @Put(':designPreset_id')
+  async updateDesignPreset(
+    @Param('designPreset_id') designPresetId: string,
+    @Body() updateDesignPresetDto: UpdateDesignPresetDto,
+  ): Promise<DesignPreset> {
+    return this.designPresetsService.updateDesignPreset(designPresetId, updateDesignPresetDto);
+  }
+
+  @Delete(':designPreset_id')
+  async deleteDesignPreset(@Param('designPreset_id') designPresetId: string): Promise<void> {
+    return this.designPresetsService.deleteDesignPreset(designPresetId);
+  }
+}

--- a/src/designPresets/designPresets.controller.ts
+++ b/src/designPresets/designPresets.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('design-presets')
+export class DesignPresetsController {}

--- a/src/designPresets/designPresets.module.ts
+++ b/src/designPresets/designPresets.module.ts
@@ -1,9 +1,14 @@
 import { Module } from '@nestjs/common';
 import { DesignPresetsController } from './designPresets.controller';
 import { DesignPresetsService } from './designPresets.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DesignPreset } from './entities/designPresets.entity';
+import { Restaurant } from 'src/restaurants/entities/restaurants.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([DesignPreset, Restaurant])],
   controllers: [DesignPresetsController],
   providers: [DesignPresetsService],
+  exports: [DesignPresetsService],
 })
 export class DesignPresetsModule {}

--- a/src/designPresets/designPresets.module.ts
+++ b/src/designPresets/designPresets.module.ts
@@ -9,6 +9,6 @@ import { Restaurant } from 'src/restaurants/entities/restaurants.entity';
   imports: [TypeOrmModule.forFeature([DesignPreset, Restaurant])],
   controllers: [DesignPresetsController],
   providers: [DesignPresetsService],
-  exports: [DesignPresetsService],
+  exports: [DesignPresetsService, TypeOrmModule],
 })
 export class DesignPresetsModule {}

--- a/src/designPresets/designPresets.module.ts
+++ b/src/designPresets/designPresets.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { DesignPresetsController } from './designPresets.controller';
+import { DesignPresetsService } from './designPresets.service';
+
+@Module({
+  controllers: [DesignPresetsController],
+  providers: [DesignPresetsService],
+})
+export class DesignPresetsModule {}

--- a/src/designPresets/designPresets.service.ts
+++ b/src/designPresets/designPresets.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class DesignPresetsService {}

--- a/src/designPresets/designPresets.service.ts
+++ b/src/designPresets/designPresets.service.ts
@@ -1,4 +1,75 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { DesignPreset } from './entities/designPresets.entity';
+import { CreateDesignPresetDto } from './dto/create-designPresets.dto';
+import { UpdateDesignPresetDto } from './dto/update-designPresets.dto';
+import { Restaurant } from 'src/restaurants/entities/restaurants.entity';
 
 @Injectable()
-export class DesignPresetsService {}
+export class DesignPresetsService {
+  constructor(
+    @InjectRepository(DesignPreset)
+    private readonly designPresetsRepository: Repository<DesignPreset>,
+
+    @InjectRepository(Restaurant)
+    private readonly restaurantRepository: Repository<Restaurant>,
+  ) {}
+
+  async getDesignPresets(restaurantId: string): Promise<DesignPreset[]> {
+    const restaurant = await this.restaurantRepository.findOne({ where: { id: restaurantId } });
+
+    if (!restaurant) {
+      throw new NotFoundException(`ID가 ${restaurantId}인 레스토랑을 찾을 수 없습니다.`);
+    }
+
+    return this.designPresetsRepository.find({ where: { restaurant } });
+  }
+
+  async getDesignPresetById(designPresetId: string): Promise<DesignPreset> {
+    const designPreset = await this.designPresetsRepository.findOne({ where: { id: designPresetId } });
+
+    if (!designPreset) {
+      throw new NotFoundException(`ID가 ${designPresetId}인 디자인 프리셋을 찾을 수 없습니다.`);
+    }
+
+    return designPreset;
+  }
+
+  async createDesignPreset(restaurantId: string, createDesignPresetDto: CreateDesignPresetDto): Promise<DesignPreset> {
+    const restaurant = await this.restaurantRepository.findOne({ where: { id: restaurantId } });
+
+    if (!restaurant) {
+      throw new NotFoundException(`ID가 ${restaurantId}인 레스토랑을 찾을 수 없습니다.`);
+    }
+
+    const newDesignPreset = this.designPresetsRepository.create({
+      ...createDesignPresetDto,
+      restaurant,
+    });
+
+    return this.designPresetsRepository.save(newDesignPreset);
+  }
+
+  async updateDesignPreset(
+    designPresetId: string,
+    updateDesignPresetDto: UpdateDesignPresetDto,
+  ): Promise<DesignPreset> {
+    const designPreset = await this.designPresetsRepository.findOne({ where: { id: designPresetId } });
+
+    if (!designPreset) {
+      throw new NotFoundException(`ID가 ${designPresetId}인 디자인 프리셋을 찾을 수 없습니다.`);
+    }
+    const updatedDesignPreset = this.designPresetsRepository.merge(designPreset, updateDesignPresetDto);
+
+    return this.designPresetsRepository.save(updatedDesignPreset);
+  }
+
+  async deleteDesignPreset(designPresetId: string): Promise<void> {
+    const result = await this.designPresetsRepository.delete(designPresetId);
+
+    if (result.affected === 0) {
+      throw new NotFoundException(`ID가 ${designPresetId}인 디자인 프리셋을 찾을 수 없습니다.`);
+    }
+  }
+}

--- a/src/designPresets/dto/create-designPresets.dto.ts
+++ b/src/designPresets/dto/create-designPresets.dto.ts
@@ -1,0 +1,67 @@
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class CreateDesignPresetDto {
+  @IsNotEmpty()
+  @IsString()
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  background?: string;
+
+  @IsOptional()
+  @IsString()
+  bigText?: string;
+
+  @IsOptional()
+  @IsString()
+  smallText?: string;
+
+  @IsOptional()
+  @IsString()
+  box?: string;
+
+  @IsOptional()
+  @IsString()
+  boxBorder?: string;
+
+  @IsOptional()
+  @IsString()
+  icon?: string;
+
+  @IsOptional()
+  @IsString()
+  buttonBackground?: string;
+
+  @IsOptional()
+  @IsString()
+  buttonText?: string;
+
+  @IsOptional()
+  @IsString()
+  buttonBorder?: string;
+
+  @IsOptional()
+  @IsString()
+  buttonActiveBackground?: string;
+
+  @IsOptional()
+  @IsString()
+  buttonActiveText?: string;
+
+  @IsOptional()
+  @IsString()
+  buttonActiveBorder?: string;
+
+  @IsOptional()
+  @IsString()
+  labelHot?: string;
+
+  @IsOptional()
+  @IsString()
+  labelNew?: string;
+
+  @IsOptional()
+  @IsString()
+  labelSoldOut?: string;
+}

--- a/src/designPresets/dto/update-designPresets.dto.ts
+++ b/src/designPresets/dto/update-designPresets.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateDesignPresetDto } from './create-designPresets.dto';
+
+export class UpdateDesignPresetDto extends PartialType(CreateDesignPresetDto) {}

--- a/src/designPresets/entities/designPresets.entity.ts
+++ b/src/designPresets/entities/designPresets.entity.ts
@@ -1,0 +1,60 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from 'typeorm';
+import { Restaurant } from 'src/restaurants/entities/restaurants.entity';
+
+@Entity('designPresets')
+export class DesignPreset {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 45 })
+  name: string;
+
+  @Column({ type: 'varchar', length: 45, nullable: true })
+  background: string;
+
+  @Column({ type: 'varchar', length: 45, name: 'big_text', nullable: true })
+  bigText: string;
+
+  @Column({ type: 'varchar', length: 45, name: 'small_text', nullable: true })
+  smallText: string;
+
+  @Column({ type: 'varchar', length: 45, nullable: true })
+  box: string;
+
+  @Column({ type: 'varchar', length: 45, name: 'box_border', nullable: true })
+  boxBorder: string;
+
+  @Column({ type: 'varchar', length: 45, nullable: true })
+  icon: string;
+
+  @Column({ type: 'varchar', length: 45, name: 'button_background', nullable: true })
+  buttonBackground: string;
+
+  @Column({ type: 'varchar', length: 45, name: 'button_text', nullable: true })
+  buttonText: string;
+
+  @Column({ type: 'varchar', length: 45, name: 'button_border', nullable: true })
+  buttonBorder: string;
+
+  @Column({ type: 'varchar', length: 45, name: 'button_active_background', nullable: true })
+  buttonActiveBackground: string;
+
+  @Column({ type: 'varchar', length: 45, name: 'button_active_text', nullable: true })
+  buttonActiveText: string;
+
+  @Column({ type: 'varchar', length: 45, name: 'button_active_border', nullable: true })
+  buttonActiveBorder: string;
+
+  @Column({ type: 'varchar', length: 45, name: 'lable_hot', nullable: true })
+  labelHot: string;
+
+  @Column({ type: 'varchar', length: 45, name: 'lable_new', nullable: true })
+  labelNew: string;
+
+  @Column({ type: 'varchar', length: 45, name: 'lable_sold_out', nullable: true })
+  labelSoldOut: string;
+
+  @ManyToOne(() => Restaurant, (restaurant) => restaurant.designPresets, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'restaurant_id' })
+  restaurant: Restaurant;
+}

--- a/src/restaurants/entities/restaurants.entity.ts
+++ b/src/restaurants/entities/restaurants.entity.ts
@@ -17,6 +17,7 @@ import { Category } from 'src/categories/entities/categories.entity';
 import { Call } from 'src/calls/entities/calls.entity';
 import { Design } from 'src/designs/entities/designs.entity';
 import { Users } from 'src/users/entities/users.entity';
+import { DesignPreset } from 'src/designPresets/entities/designPresets.entity';
 
 @Entity('restaurants')
 export class Restaurant {
@@ -75,4 +76,7 @@ export class Restaurant {
 
   @OneToMany(() => Design, (design) => design.restaurant)
   designs: Design[];
+
+  @OneToMany(() => DesignPreset, (designPreset) => designPreset.restaurant)
+  designPresets: DesignPreset[];
 }

--- a/src/restaurants/restaurants.module.ts
+++ b/src/restaurants/restaurants.module.ts
@@ -7,13 +7,13 @@ import { RestaurantTable } from 'src/restaurantTables/entities/restaurantTables.
 import { Url } from 'src/urls/entities/urls.entity';
 import { UrlsService } from 'src/urls/urls.service';
 import { Order } from 'src/orders/entities/orders.entity';
-import { DesignsModule } from 'src/designs/designs.module';
 import { UsersModule } from 'src/users/users.module';
+import { DesignPresetsModule } from 'src/designPresets/designPresets.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Restaurant, RestaurantTable, Url, Order]),
-    DesignsModule,
+    DesignPresetsModule,
     forwardRef(() => UsersModule),
   ],
   controllers: [RestaurantsController],

--- a/src/restaurants/restaurants.service.ts
+++ b/src/restaurants/restaurants.service.ts
@@ -6,8 +6,8 @@ import { CreateRestaurantDto } from './dto/create-restaurants.dto';
 import { UpdateRestaurantDto } from './dto/update-restaurants.dto';
 import { RestaurantTable } from 'src/restaurantTables/entities/restaurantTables.entity';
 import { UrlsService } from 'src/urls/urls.service';
-import { Design } from 'src/designs/entities/designs.entity';
 import { Users } from 'src/users/entities/users.entity';
+import { DesignPreset } from 'src/designPresets/entities/designPresets.entity';
 
 @Injectable()
 export class RestaurantsService {
@@ -18,8 +18,8 @@ export class RestaurantsService {
     @InjectRepository(RestaurantTable)
     private readonly restaurantTableRepository: Repository<RestaurantTable>,
 
-    @InjectRepository(Design)
-    private readonly designRepository: Repository<Design>,
+    @InjectRepository(DesignPreset)
+    private readonly designPresetRepository: Repository<DesignPreset>,
 
     @InjectRepository(Users)
     private readonly userRepository: Repository<Users>,
@@ -61,10 +61,11 @@ export class RestaurantsService {
       await this.urlsService.createUrl(savedRestaurant, i);
     }
 
-    const newDesign = this.designRepository.create({
+    const newDesignPreset = this.designPresetRepository.create({
       restaurant: savedRestaurant,
+      name: '기본 디자인',
     });
-    await this.designRepository.save(newDesign);
+    await this.designPresetRepository.save(newDesignPreset);
 
     return savedRestaurant;
   }


### PR DESCRIPTION
### 작업 개요
- designPresets API 개발
- 기존의 designs entity에 name 추가 후 designPresets로 변경
- 디자인 프리셋 전체조회 메소드 개발
- 디자인 프리셋 개별 조회, 생성, 수정, 삭제 메소드 개발
- 식당 생성시 디자인 생성 -> '기본 디자인' 디자인 프리셋 생성으로 변경

### 반영 브랜치
feat_designPresets -> dev

### 연관된 이슈(optional)
- #72 

### 기타 참고 사항(optional)
- 추후 기본 디자인의 컬러값이 정해지면 기본 디자인이 생성될 때 해당 컬러값이 들어가도록 변경할 예정입니다.

### 체크리스트
- [x] 코드가 정상적으로 작동하고 모든 테스트를 통과했나요?
- [x] 문서화가 필요한 경우, 문서화가 완료되었나요?
- [x] 코드 스타일 가이드라인을 따랐나요?
- [x] 관련된 모든 이슈가 링크되었나요?
- [x] 필요한 경우, 팀원에게 알렸나요?
